### PR TITLE
use \r\n as CRLF, not just \n

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -26,7 +26,7 @@ func newConsumer(resp http.ResponseWriter, req *http.Request, es *eventSource) (
 		staled: false,
 	}
 
-	_, err = conn.Write([]byte("HTTP/1.1 200 OK\nContent-Type: text/event-stream\n"))
+	_, err = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n"))
 	if err != nil {
 		conn.Close()
 		return nil, err
@@ -39,7 +39,7 @@ func newConsumer(resp http.ResponseWriter, req *http.Request, es *eventSource) (
 				conn.Close()
 				return nil, err
 			}
-			_, err = conn.Write([]byte("\n"))
+			_, err = conn.Write([]byte("\r\n"))
 			if err != nil {
 				conn.Close()
 				return nil, err
@@ -47,7 +47,7 @@ func newConsumer(resp http.ResponseWriter, req *http.Request, es *eventSource) (
 		}
 	}
 
-	_, err = conn.Write([]byte("\n"))
+	_, err = conn.Write([]byte("\r\n"))
 	if err != nil {
 		conn.Close()
 		return nil, err


### PR DESCRIPTION
Heroku recently updated to a stricter router. Because of this, using `\n` as a terminator is no longer sufficient. Following RFC2616 and using `\r\n` fixes the problem.

http://stackoverflow.com/questions/5757290/http-header-line-break-style#answer-5757349
