### PR TITLE
put eventsource in its own package

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -1,4 +1,4 @@
-package http
+package eventsource
 
 import (
 	"net"

--- a/doc.go
+++ b/doc.go
@@ -28,4 +28,4 @@ Example:
             log.Fatal(http.ListenAndServe(":8080", nil))
         }
 */
-package http
+package eventsource

--- a/eventsource.go
+++ b/eventsource.go
@@ -1,4 +1,4 @@
-package http
+package eventsource
 
 import (
 	"bytes"

--- a/eventsource_test.go
+++ b/eventsource_test.go
@@ -1,4 +1,4 @@
-package http
+package eventsource
 
 import (
 	"io"


### PR DESCRIPTION
Currently, because it is declared in `package http`, when I use this package I import it as

``` go
import (
    eventsource "github.com/antage/eventsource"
)
```

Is there a reason not to name the package `eventsource`? I could change my import statements to

``` go
import (
   "github.com/antage/eventsource"
)
```

Not a big deal, but it is more expected.
