### PR TITLE
Do not close any channels to avoid racy "send on closed channel" panics

### DIFF
--- a/eventsource.go
+++ b/eventsource.go
@@ -128,25 +128,6 @@ func controlProcess(es *eventSource) {
 				}
 			}()
 		case <-es.close:
-			close(es.sink)
-			close(es.add)
-			close(es.staled)
-			close(es.close)
-
-			func() {
-				es.consumersLock.RLock()
-				defer es.consumersLock.RUnlock()
-
-				for e := es.consumers.Front(); e != nil; e = e.Next() {
-					c := e.Value.(*consumer)
-					close(c.in)
-				}
-			}()
-
-			es.consumersLock.Lock()
-			defer es.consumersLock.Unlock()
-
-			es.consumers.Init()
 			return
 		case c := <-es.add:
 			func() {
@@ -175,7 +156,6 @@ func controlProcess(es *eventSource) {
 					es.consumers.Remove(e)
 				}
 			}()
-			close(c.in)
 		}
 	}
 }


### PR DESCRIPTION
Example panic, happened after the eventsource was closed:

```
panic: runtime error: send on closed channel

goroutine 147858 [running]:
runtime.panic(0x465000, 0x77641e)
    /usr/local/Cellar/go/1.3.1/libexec/src/pkg/runtime/panic.c:279 +0xf5
github.com/sporttech/eventsource.func·001()
    /Users/mrbrbr/dev/go/src/github.com/sporttech/eventsource/consumer.go:73 +0x384
```

There is no need to close any channels — it does not impact the GC, but
is only a signal to receivers that no data will be following (see
[here](https://groups.google.com/forum/#!msg/golang-nuts/pZwdYRGxCIk/qpbHxRRPJdUJ)).

As nothing in this package listens to `close()` of any channel, simply
removing all `close()` calls both simplifies the code and avoids
unexpected `panic()`s.
