### PR TITLE
Disable Gzip by default

### DIFF
--- a/eventsource.go
+++ b/eventsource.go
@@ -60,7 +60,7 @@ type Settings struct {
 	// Gzip sets whether to use gzip Content-Encoding for clients which
 	// support it.
 	//
-	// The default is true.
+	// The default is false.
 	Gzip bool
 }
 
@@ -69,7 +69,7 @@ func DefaultSettings() *Settings {
 		Timeout:        2 * time.Second,
 		CloseOnTimeout: true,
 		IdleTimeout:    30 * time.Minute,
-		Gzip:           true,
+		Gzip:           false,
 	}
 }
 


### PR DESCRIPTION
Golang's Gzip implementation will allocate a ~1MB buffer per connection. This really adds up when you have more than a thousand consumers listening for events.
I think it would be best to turn off Gzip to save some memory.

Here are some heap profiles taken from an eventsource program with about 30 consumers to illustrate the problem:
[With compression](https://github.com/antage/eventsource/files/200995/gzip.pdf)
[Without compression](https://github.com/antage/eventsource/files/200996/plain.pdf)

Having Gzip enabled for will probably not be beneficial in most cases since the sent messages are very short anyway. If people really need compression when sending large messages they can just re-enable it via the config.