### PR TITLE
Add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/antage/eventsource
+
+go 1.18


### PR DESCRIPTION
This adds a go.mod file to the repo, making it more compliant with Go modules. Things are compiling fine without it, but the missing go.mod does confuse some Go tooling into thinking it's not a library.